### PR TITLE
Do not copy symlink

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,7 +37,7 @@ runs:
             echo "### Copy runner files from the running runner:"
             echo "    - runner_path: $RUNNER_PATH"
             # We need to exclude temp/state related files when copying the existing runner files.
-            rsync -a ${RUNNER_PATH}/ . --exclude "_*" --exclude ".*"
+            rsync --copy-links -a ${RUNNER_PATH}/ . --exclude "_*" --exclude ".*"
         else
             DOWNLOAD_URL="https://github.com/actions/runner/releases/download/v${{ inputs.runner-version }}/actions-runner-linux-x64-${{ inputs.runner-version }}.tar.gz"
             echo "### Download runner files:"


### PR DESCRIPTION
actions/runner will auto-update in github.com, and create symlink ./bin and ./externals.
So `rsync` does not need link files in a copied directory.

## Log

1. Failed to refresh runner

```
Run cycloud-io/refresh-runner-action@v1.1.0
### Copy runner files from the running runner:
    - runner_path: /tmp/runner
Prepared dummy runner version: 2.280.3
### Configure dummy runner

--------------------------------------------------------------------------------
|        ____ _ _   _   _       _          _        _   _                      |
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      |
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     |
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     |
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     |
|                                                                              |
|                       Self-hosted runner registration                        |
|                                                                              |
--------------------------------------------------------------------------------
Cannot configure the runner because it is already configured. To reconfigure the runner, run 'config.cmd remove' or './config.sh remove' first.
Error: Process completed with exit code 1.
```

2. Check `actions-runner` directory, created symlink `bin` and `externals` and linked to under `${RUNNER_PATH`.

```
$ ls -l ${RUNNER_PATH}/_work/github-actions-scripts/github-actions-scripts/actions-runner
total 28
drwxrwxr-x 1 ubuntu ubuntu    60 Aug 31 18:49 _diag
lrwxrwxrwx 1 ubuntu ubuntu    90 Aug 31 18:49 bin -> ${RUNNER_PATH}/bin.2.280.3
drwxr-xr-x 1 ubuntu docker 12398 Dec 15  2020 bin.2.275.1
drwxrwxr-x 1 ubuntu ubuntu 12428 Aug 31 18:48 bin.2.280.3
-rwxr-xr-x 1 ubuntu docker  2452 Aug 19 22:11 config.sh
-rwxr-xr-x 1 ubuntu docker   646 Aug 19 22:11 env.sh
lrwxrwxrwx 1 ubuntu ubuntu    29 Aug 31 18:31 externals -> ${RUNNER_PATH}/externals.2.280.3
drwxr-xr-x 1 ubuntu docker    38 Dec 15  2020 externals.2.275.1
drwxrwxr-x 1 ubuntu ubuntu    38 Aug 31 18:31 externals.2.280.3
-rwxr-xr-x 1 ubuntu docker  1598 Aug 19 22:11 run.sh
-rwxr-xr-x 1 ubuntu ubuntu  4874 Aug 31 18:50 svc.sh
```